### PR TITLE
Fixed Laravel 5 Form highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Syntax Highlight for:
 * Comments: **{{-- --}}**
 * Laravel 4: **{{  }}**
 * Laravel 5: **{%  %}**
+* Laravel 5: **{!! !!}**
 
 ###**Current State**
 Currently this extension supports only basic syntax, I plan to add support for the full Laravel Blade template system.

--- a/src/bladesyntaxhighligh.js
+++ b/src/bladesyntaxhighligh.js
@@ -51,7 +51,7 @@ define(function (require, exports, module) {
 				//Laravel5 Form Syntax
 				if (stream.match("{!!")) {
 					while ((ch = stream.next()) != null)
-						if (ch == "!" && stream.next() == "}") {
+						if (ch == "!" && stream.next() == "!" && stream.next() == "}") {
 							stream.eat("}");
 							return "def";
 						}


### PR DESCRIPTION
Highlighting was assuming the pattern `{!! … !}`, it is now fixed to
the correct `{!! … !!}`.